### PR TITLE
rename pex subckt to r2r_pex, use file normalize to generate absolute…

### DIFF
--- a/mag/r2r.sim.spice
+++ b/mag/r2r.sim.spice
@@ -1,6 +1,6 @@
 * NGSPICE file created from r2r.ext - technology: sky130A
 
-.subckt r2r b0 b1 b2 b3 b4 b5 b6 b7 out GND
+.subckt r2r_pex b0 b1 b2 b3 b4 b5 b6 b7 out GND
 X0 a_766_6998# a_1366_2566# a_n1964_2436# sky130_fd_pr__res_high_po_0p35 l=20
 X1 b0.t0 a_n1834_10998# a_n1964_2436# sky130_fd_pr__res_high_po_0p35 l=40
 X2 b6.t0 a_1966_6998# a_n1964_2436# sky130_fd_pr__res_high_po_0p35 l=40

--- a/xschem/testbench.sch
+++ b/xschem/testbench.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {}
@@ -209,8 +209,8 @@ C {devices/lab_pin.sym} -920 70 0 0 {name=p17 sig_type=std_logic lab=b4
 
 }
 C {r2r.sym} -810 650 0 0 {name=x2
-schematic=r2r.sim
-spice_sym_def=".include ../../mag/r2r.sim.spice"
+schematic=r2r_pex
+spice_sym_def="tcleval(.include [file normalize ../mag/r2r.sim.spice])"
 tclcommand="textwindow ../mag/r2r.sim.spice"}
 C {devices/lab_pin.sym} -960 630 0 0 {name=p18 sig_type=std_logic lab=b0}
 C {devices/lab_pin.sym} -960 610 0 0 {name=p19 sig_type=std_logic lab=b1}

--- a/xschem/xschemrc
+++ b/xschem/xschemrc
@@ -438,3 +438,4 @@ append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem
 if { [info exists ::env(XSCHEM_USER_LIBRARY_PATH) ] } {
     append XSCHEM_LIBRARY_PATH :$env(XSCHEM_USER_LIBRARY_PATH)
 }
+append XSCHEM_LIBRARY_PATH :[pwd]


### PR DESCRIPTION
this makes your example work as expected.
schematic and pex outputs look identical since resistors are rather small in value and not affected by some fF of parasitic capacitance. However add a 100pF capacitor on out node in r2r.sim.spice:
`cout out 0 100p`
and you see the effect:
![1](https://github.com/mattvenn/tt06-analog-r2r-dac/assets/69359491/6d232e79-fa75-4e28-8550-b803fe9b3762)
